### PR TITLE
Feature/grow 27 setup debugger

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
     "start": "expo start",
+    "debug": "open 'rndebugger://set-debugger-loc?host=localhost&port=19000' && expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -1,4 +1,4 @@
-import { combineReducers, createStore } from 'redux';
+import { applyMiddleware, combineReducers, compose, createStore } from 'redux';
 
 import { authReducer } from './auth/authReducer';
 
@@ -6,6 +6,11 @@ const baseReducer = combineReducers({
   auth: authReducer,
 });
 
-export type RootState = ReturnType<typeof store.getState>
+export type RootState = ReturnType<typeof store.getState>;
 
-export const store = createStore(baseReducer);
+const middleware: any[] = [];
+const composeEnhancers = (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+export const store = createStore(
+  baseReducer,
+  composeEnhancers(applyMiddleware(...middleware)),
+);


### PR DESCRIPTION
## Context

**MERGE INTO DEVELOP!**

I configured the store so that the app is clickable and added `npm run debug` script which launches the standalone debugger.

## Resources

- [A Thorough Guide to Install React Native Debugger to an Expo App](https://medium.com/@tetsuyahasegawa/how-to-integrate-react-native-debugger-to-your-expo-react-native-project-db1d631fad02) by Tetsuya Hasegawa at [medium.com](https://medium.com/)
- [Redux Devtools Github repository](https://github.com/zalmoxisus/redux-devtools-extension#11-basic-store)

## Test path

1. Install [react-native-debugger](https://github.com/jhen0409/react-native-debugger/releases).
2. Run `npm run debug`.
3. Open application, shake the phone and select "Debug JS Remotely".

**Expected result**:

Application info shows up in the standalone debugger application (React and Redux devtools).

## Checklist

- [ ] I checked the diff
- [ ] I formatted the code
- [ ] I wrote tests
