### PR TITLE
Feature/grow 28 add basic authentication flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@react-navigation/bottom-tabs": "^6.0.9",
     "@react-navigation/native": "^6.0.6",
+    "@react-navigation/native-stack": "^6.2.5",
     "expo": "~43.0.0",
     "expo-status-bar": "~1.1.0",
     "immer": "^9.0.6",

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -1,16 +1,32 @@
 import { NavigationContainer } from '@react-navigation/native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { useSelector } from 'react-redux';
 
+import { AuthScreen } from 'Screens/AuthScreen';
 import { HomeScreen } from 'Screens/HomeScreen';
 import { ProfileScreen } from 'Screens/ProfileScreen';
 
-const Tab = createBottomTabNavigator();
+import { isSignedInSelector } from './redux/auth/authSelectors';
 
-export const Navigation = () => (
-  <NavigationContainer>
-    <Tab.Navigator>
-      <Tab.Screen name="Home" component={HomeScreen} />
-      <Tab.Screen name="Profile" component={ProfileScreen} />
-    </Tab.Navigator>
-  </NavigationContainer>
-);
+const Tab = createBottomTabNavigator();
+const Stack = createNativeStackNavigator();
+
+export const Navigation = () => {
+  const isSignedIn = useSelector(isSignedInSelector);
+
+  return (
+    <NavigationContainer>
+      {isSignedIn ? (
+        <Tab.Navigator>
+          <Tab.Screen name="Home" component={HomeScreen} />
+          <Tab.Screen name="Profile" component={ProfileScreen} />
+        </Tab.Navigator>
+      ) : (
+        <Stack.Navigator>
+          <Stack.Screen name="Authentication" component={AuthScreen} options={{ headerShown: false }} />
+        </Stack.Navigator>
+      )}
+    </NavigationContainer>
+  );
+};

--- a/src/enums/EAuthContext.ts
+++ b/src/enums/EAuthContext.ts
@@ -1,0 +1,4 @@
+export enum EAuthContext {
+  SIGN_IN = 'SIGN_IN',
+  SIGN_UP = 'SIGN_UP',
+}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,55 @@
+import { useDispatch } from 'react-redux';
+import { useState } from 'react';
+
+import { EAuthContext } from '../enums/EAuthContext';
+import { authContextMap } from 'Screens/AuthScreen.constants';
+import { signIn } from '../redux/auth/authActions';
+
+type UseAuthType = (
+  username: string,
+  password: string,
+  repeatedPassword: string,
+) => {
+  additionalInfo: string,
+  changeContext: () => void,
+  handlePrimaryButtonPress: () => void;
+  isLogInContext: boolean;
+  primaryButtonTitle: string;
+  secondaryButtonTitle: string;
+};
+
+export const useAuth: UseAuthType = (username, password, repeatedPassword) => {
+  const dispatch = useDispatch();
+
+  const [context, setContext] = useState(EAuthContext.SIGN_IN);
+
+  const isLogInContext = context === EAuthContext.SIGN_IN;
+
+  const getSecondContext = () =>
+    isLogInContext ? EAuthContext.SIGN_UP : EAuthContext.SIGN_IN;
+
+  const changeContext = () => setContext(getSecondContext());
+
+  const handleLogin = () => dispatch(signIn()); // TODO: pass username and password
+
+  const handleRegistration = () => {
+    if (username && password === repeatedPassword) {
+      // dispatch(registerUser({ username, password })); // TODO: add register action
+      changeContext();
+    }
+  };
+
+  const handlePrimaryButtonPress = () => {
+    if (isLogInContext) return handleLogin();
+    handleRegistration();
+  };
+
+  return {
+    additionalInfo: authContextMap[getSecondContext()].info,
+    changeContext,
+    handlePrimaryButtonPress,
+    isLogInContext,
+    primaryButtonTitle: authContextMap[context].buttonTitle,
+    secondaryButtonTitle: authContextMap[getSecondContext()].buttonTitle,
+  };
+};

--- a/src/hooks/useInput.ts
+++ b/src/hooks/useInput.ts
@@ -1,0 +1,17 @@
+import { useState } from 'react';
+
+type UseInputType = (
+  initialValue: string,
+) => [
+  value: string,
+  handleValue: (text: string) => void,
+  setValue: (value: string) => void,
+];
+
+export const useInput: UseInputType = (initialValue) => {
+  const [value, setValue] = useState(initialValue);
+
+  const handleValue = (text: string) => setValue(text);
+
+  return [value, handleValue, setValue];
+};

--- a/src/redux/auth/authReducer.ts
+++ b/src/redux/auth/authReducer.ts
@@ -8,7 +8,7 @@ interface IAuthState {
 }
 
 const initialState: IAuthState = {
-  isSignedIn: true, // TODO: change to false when authorization flow is set up
+  isSignedIn: false,
 };
 
 export const authReducer = produce((draftState, { type }: AuthActionsType) => {

--- a/src/screens/AuthScreen.constants.ts
+++ b/src/screens/AuthScreen.constants.ts
@@ -1,0 +1,12 @@
+import { EAuthContext } from '../enums/EAuthContext';
+
+export const authContextMap = {
+  [EAuthContext.SIGN_IN]: {
+    info: 'You have an account?',
+    buttonTitle: 'Sign in',
+  },
+  [EAuthContext.SIGN_UP]: {
+    info: "You don't have an account?",
+    buttonTitle: 'Sign up',
+  },
+};

--- a/src/screens/AuthScreen.styles.ts
+++ b/src/screens/AuthScreen.styles.ts
@@ -1,0 +1,28 @@
+import { StyleSheet } from 'react-native';
+
+// TODO: extract duplicated styles
+export const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  signInContainer: {
+    flex: 0.8,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  switchContextContainer: {
+    flex: 0.2,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  textInput: {
+    backgroundColor: 'white',
+    borderRadius: 5,
+    height: 40,
+    margin: 5,
+    padding: 15,
+    width: 200,
+  },
+});

--- a/src/screens/AuthScreen.tsx
+++ b/src/screens/AuthScreen.tsx
@@ -1,0 +1,57 @@
+import { Button, Text, TextInput, View } from 'react-native';
+
+import { styles } from './AuthScreen.styles';
+import { useAuth } from '../hooks/useAuth';
+import { useInput } from '../hooks/useInput';
+
+export const AuthScreen = () => {
+  const [username, handleUsernameChange] = useInput('');
+  const [password, handlePasswordChange] = useInput('');
+  const [repeatedPassword, handleRepeatedPasswordChange] = useInput('');
+
+  const {
+    additionalInfo,
+    changeContext,
+    handlePrimaryButtonPress,
+    isLogInContext,
+    primaryButtonTitle,
+    secondaryButtonTitle,
+  } = useAuth(username, password, repeatedPassword);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.signInContainer}>
+        <TextInput
+          style={styles.textInput}
+          placeholder="E-mail"
+          onChangeText={handleUsernameChange}
+          value={username}
+        />
+        <TextInput
+          style={styles.textInput}
+          placeholder="Password"
+          onChangeText={handlePasswordChange}
+          secureTextEntry
+          autoCorrect={false}
+          value={password}
+        />
+        {!isLogInContext && (
+          <TextInput
+            style={styles.textInput}
+            placeholder="Repeat password"
+            onChangeText={handleRepeatedPasswordChange}
+            secureTextEntry
+            autoCorrect={false}
+            value={repeatedPassword}
+          />
+        )}
+        <Button title={primaryButtonTitle} onPress={handlePrimaryButtonPress} />
+        {isLogInContext && <Text>I forgot my password.</Text>}
+      </View>
+      <View style={styles.switchContextContainer}>
+        <Text>{additionalInfo}</Text>
+        <Button title={secondaryButtonTitle} onPress={changeContext} />
+      </View>
+    </View>
+  );
+};

--- a/src/screens/ProfileScreen.styles.ts
+++ b/src/screens/ProfileScreen.styles.ts
@@ -1,0 +1,10 @@
+import { StyleSheet } from 'react-native';
+
+// TODO: extract duplicated styles
+export const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -1,9 +1,17 @@
-import { Text, View } from 'react-native';
+import { Button, View } from 'react-native';
+import { useDispatch } from 'react-redux';
+
+import { signOut } from '../redux/auth/authActions';
+import { styles } from './ProfileScreen.styles';
 
 export const ProfileScreen = () => {
+  const dispatch = useDispatch();
+
+  const handleLogOut = () => dispatch(signOut());
+
   return (
-    <View>
-      <Text>Profile screen</Text>
+    <View style={styles.container}>
+      <Button title="Log out" onPress={handleLogOut} />
     </View>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1421,6 +1421,14 @@
   resolved "https://registry.yarnpkg.com/@react-navigation/elements/-/elements-1.2.1.tgz#86f19781c6f34a5c9dd25dca99915e0306f477d1"
   integrity sha512-EnmAbKMsptrliRKf95rdgS6BhMjML+mIns06+G1Vdih6BrEo7/0iytThUv3WBf99AI76dyEq/cqLUwHPiFzXWg==
 
+"@react-navigation/native-stack@^6.2.5":
+  version "6.2.5"
+  resolved "https://registry.yarnpkg.com/@react-navigation/native-stack/-/native-stack-6.2.5.tgz#bfa19516cf434f831e6d4ba28d32b9bc5436d181"
+  integrity sha512-XCtwl4LEr06nzxMG4aXbYfbO/pAjyhGOR3QtBVBq/uGfVGkeK8utKUe925reqd1x099CiEfSJLpgeR2KzzYp+Q==
+  dependencies:
+    "@react-navigation/elements" "^1.2.1"
+    warn-once "^0.1.0"
+
 "@react-navigation/native@^6.0.6":
   version "6.0.6"
   resolved "https://registry.yarnpkg.com/@react-navigation/native/-/native-6.0.6.tgz#0f2577358d73d7b21ff5b2455f0a2d51b1ad2837"


### PR DESCRIPTION
## Context

- I installed stack navigator,
- I set up authentication flow navigation along with the linked resource.

## Resources

- [Authentication flows](https://reactnavigation.org/docs/auth-flow/) at [reactnavigation.org](https://reactnavigation.org/)

## Test path

1. Turn on the app.
2. Mess around with Sign in and Sign up screens.
3. Log out from Profile screen.

**Expected result**:

Everything works!

## Checklist

- [x] I checked the diff
- [x] I formatted the code
- [ ] I wrote tests
